### PR TITLE
v3.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.4
+current_version = 3.0.0
 commit = true
 tag = false
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -197,19 +197,19 @@ Normally you"d only need a single instance of your profile class.
 Get Concrete Profile
 ^^^^^^^^^^^^^^^^^^^^
 
-To work with a concrete profile which may not necessarily be activated, use ``get_instance``
+To work with a concrete profile which may not necessarily be activated, use ``load``
 factory method:
 
 .. code-block:: python
 
-    staging = WarehouseProfile.get_instance("staging")
+    staging = WarehouseProfile.load("staging")
 
 By default, this profile will be frozen which means it will be loaded only once during instantiation.
 If you want it to always consult environment variables, pass ``is_live=True``:
 
 .. code-block:: python
 
-    staging = WarehouseProfile.get_instance("staging", is_live=True)
+    staging = WarehouseProfile.load("staging", is_live=True)
 
 
 Activate Profile

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -10,7 +10,7 @@ def test_activates_live_profile(profile_name):
     instance = WarehouseProfile(name=profile_name)
     instance.activate()
 
-    assert wp.active_profile_name == profile_name
+    assert wp._active_profile_name == profile_name
     assert instance.is_active
 
 
@@ -22,17 +22,17 @@ def test_activates_frozen_profile(profile_name):
     instance.activate()
 
     assert instance.is_active
-    assert wp.active_profile_name == profile_name
+    assert wp._active_profile_name == profile_name
 
 
 def test_activates_named_profile():
     wp = WarehouseProfile()
 
     wp.activate("staging")
-    assert wp.active_profile_name == "staging"
+    assert wp._active_profile_name == "staging"
 
     wp.activate("production")
-    assert wp.active_profile_name == "production"
+    assert wp._active_profile_name == "production"
 
     wp.activate(None)
-    assert wp.active_profile_name is None
+    assert wp._active_profile_name is None

--- a/tests/test_concepts.py
+++ b/tests/test_concepts.py
@@ -11,7 +11,7 @@ def test_default_profile_is_active_and_live():
 def test_custom_profile_is_frozen_but_could_be_active(monkeypatch):
     monkeypatch.setenv("WAREHOUSE_PROFILE", "staging")
 
-    profile = WarehouseProfile.get_instance("staging")
+    profile = WarehouseProfile.load("staging")
     assert profile.profile_name == "staging"
     assert profile.is_active
 

--- a/tests/test_delegate_profile.py
+++ b/tests/test_delegate_profile.py
@@ -1,7 +1,3 @@
-# TODO Perhaps its best to namespace all Profile methods because Profile class is for user and we don't want to
-# TODO inundate them with a lot of confusing attributes like "load", "active_profile_name" etc.
-# TODO Can we make them private? Or prefix with "profile_" ?
-
 import os
 
 from wr_profiles import Profile, Property
@@ -27,11 +23,11 @@ class AppTestProfile(AppProfile):
 
 profile = AppProfile()
 
-# sandbox_profile = AppProfile.get_instance("sandbox")
+# sandbox_profile = AppProfile.load("sandbox")
 # sandbox_profile.set_prop_value("password", "sandbox-password")
 # os.environ.update(sandbox_profile.to_envvars())  # TODO ability to exclude defaults?
 
-test_profile = AppTestProfile.get_instance("sandbox", is_live=True)
+test_profile = AppTestProfile.load("sandbox", is_live=True)
 assert test_profile.host == 'test-host'
 assert test_profile.username == 'test-username'
 assert test_profile.password == 'test-password'

--- a/tests/test_delegate_profile.py
+++ b/tests/test_delegate_profile.py
@@ -1,0 +1,50 @@
+# TODO Perhaps its best to namespace all Profile methods because Profile class is for user and we don't want to
+# TODO inundate them with a lot of confusing attributes like "load", "active_profile_name" etc.
+# TODO Can we make them private? Or prefix with "profile_" ?
+
+import os
+
+from wr_profiles import Profile, Property
+
+
+class AppProfile(Profile):
+    profile_root = "app"
+
+    host = Property(default="localhost")
+    username = Property(default="root")
+    password = Property()
+
+
+class AppTestProfile(AppProfile):
+    # This is how you tell that this profile must load the active profile based on APP_TEST_PROFILE envvar
+    profile_activating_envvar = "APP_TEST_PROFILE"
+
+    # This is how you customise inherited properties:
+    host = AppProfile.password.replace(default="test-host")
+    username = AppProfile.username.replace(default="test-username")
+    password = AppProfile.password.replace(default="test-password")
+
+
+profile = AppProfile()
+
+# sandbox_profile = AppProfile.get_instance("sandbox")
+# sandbox_profile.set_prop_value("password", "sandbox-password")
+# os.environ.update(sandbox_profile.to_envvars())  # TODO ability to exclude defaults?
+
+test_profile = AppTestProfile.get_instance("sandbox", is_live=True)
+assert test_profile.host == 'test-host'
+assert test_profile.username == 'test-username'
+assert test_profile.password == 'test-password'
+
+print(test_profile.to_dict())  # TODO ability to export str names instead of Property instances as names
+
+os.environ["APP_SANDBOX_PASSWORD"] = "sandbox-password"
+assert test_profile.password == "sandbox-password"
+
+fully_live_test_profile = AppTestProfile()
+
+os.environ["APP_TEST_PROFILE"] = "integration"
+os.environ["APP_INTEGRATION_HOST"] = "int.localhost"
+
+print(fully_live_test_profile.to_dict())
+assert fully_live_test_profile.host == "int.localhost"

--- a/tests/test_delegate_profile.py
+++ b/tests/test_delegate_profile.py
@@ -2,7 +2,6 @@ import os
 
 from wr_profiles import Profile, Property
 
-
 # TODO consider sqlalchemy-like access to a bound property:
 # profile = AppProfile()
 # profile.p.username -- it's not profile.username (the value), but AppProfile.username yet bound to profile instance.

--- a/tests/test_delegate_profile.py
+++ b/tests/test_delegate_profile.py
@@ -3,6 +3,11 @@ import os
 from wr_profiles import Profile, Property
 
 
+# TODO consider sqlalchemy-like access to a bound property:
+# profile = AppProfile()
+# profile.p.username -- it's not profile.username (the value), but AppProfile.username yet bound to profile instance.
+
+
 class AppProfile(Profile):
     profile_root = "app"
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -13,8 +13,8 @@ def test_ultimate_live_profile():
     assert profile.is_live is True
 
     assert not profile.profile_name
-    assert not profile.parent_profile_name
-    assert not profile.parent_profile
+    assert not profile._profile_parent_name
+    assert not profile._profile_parent
 
     assert profile.is_active
 
@@ -39,7 +39,7 @@ def test_concrete_frozen_profile(monkeypatch):
     assert live.host == "localhost"
     assert frozen.host == "localhost"
 
-    frozen.load()
+    frozen._do_load()
 
     assert live.host == frozen.host
     assert live.username == frozen.username

--- a/tests/test_frozen_profile_with_const_values.py
+++ b/tests/test_frozen_profile_with_const_values.py
@@ -5,7 +5,7 @@ from tests.warehouse_profile import WarehouseProfile
 
 @pytest.mark.parametrize("profile_name", ["staging", None])
 def test_const_values_set_on_frozen_profile_instance(profile_name, monkeypatch):
-    wp = WarehouseProfile.get_instance(
+    wp = WarehouseProfile.load(
         name=profile_name, values={"host": "localhost.test", "username": "test"}
     )
 
@@ -19,7 +19,7 @@ def test_const_values_set_on_frozen_profile_instance(profile_name, monkeypatch):
 
 
 def test_frozen_profile_with_defaults(monkeypatch):
-    wp = WarehouseProfile.get_instance(
+    wp = WarehouseProfile.load(
         name="staging",
         defaults={"host": "default-host", "username": "default-username"},
     )
@@ -38,6 +38,6 @@ def test_frozen_profile_with_defaults(monkeypatch):
     assert wp.host == "default-host"
     assert wp.username == "default-username"
 
-    wp.load()
+    wp._do_load()
     assert wp.host == "custom-host"
     assert wp.username == "default-username"

--- a/tests/test_profiles_matrix.py
+++ b/tests/test_profiles_matrix.py
@@ -20,12 +20,12 @@ def test_parent_profile_initialisation(case):
     profile_name, parent_profile_name, is_live = case[0]
     profile = WP(name=profile_name, parent_name=parent_profile_name, is_live=is_live)
     if case[1]["parent_profile"] is None:
-        assert profile.parent_profile is None
+        assert profile._profile_parent is None
     else:
         parent_profile_sig = (
-            profile.parent_profile.profile_name,
-            profile.parent_profile.parent_profile_name,
-            profile.parent_profile.is_live,
+            profile._profile_parent.profile_name,
+            profile._profile_parent._profile_parent_name,
+            profile._profile_parent.is_live,
         )
         assert parent_profile_sig == case[1]["parent_profile"]
 
@@ -45,25 +45,25 @@ def test_parent_profile_name(monkeypatch):
 
     monkeypatch.setenv("WAREHOUSE_STAGING_PARENT_PROFILE", "production")
 
-    assert WP().parent_profile_name is None
-    assert WP().parent_profile is None
+    assert WP()._profile_parent_name is None
+    assert WP()._profile_parent is None
 
-    assert WP(name="production").parent_profile_name is None
-    assert WP(name="production").parent_profile is None
+    assert WP(name="production")._profile_parent_name is None
+    assert WP(name="production")._profile_parent is None
 
-    assert WP(name="production", is_live=False).parent_profile_name is None
-    assert WP(name="production", is_live=False).parent_profile is None
+    assert WP(name="production", is_live=False)._profile_parent_name is None
+    assert WP(name="production", is_live=False)._profile_parent is None
 
-    assert WP(name="staging").parent_profile_name == "production"
-    assert WP(name="staging").parent_profile.profile_name == "production"
+    assert WP(name="staging")._profile_parent_name == "production"
+    assert WP(name="staging")._profile_parent.profile_name == "production"
 
-    assert WP(name="staging", is_live=False).parent_profile_name is None
-    assert WP(name="staging", is_live=False).parent_profile is None
+    assert WP(name="staging", is_live=False)._profile_parent_name is None
+    assert WP(name="staging", is_live=False)._profile_parent is None
 
 
 def test_loaders():
-    assert WP().loader is Profile._profile_loaders["live"]
-    assert WP(is_live=False).loader is Profile._profile_loaders["frozen"]
+    assert WP()._loader is Profile._profile_loaders["live"]
+    assert WP(is_live=False)._loader is Profile._profile_loaders["frozen"]
 
 
 def test_to_dict():

--- a/wr_profiles/__init__.py
+++ b/wr_profiles/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2.4"
+__version__ = "3.0.0"
 
 from .profile import Profile
 from .props import Property

--- a/wr_profiles/profile.py
+++ b/wr_profiles/profile.py
@@ -155,6 +155,12 @@ class Profile:
 
     profile_root = None
 
+    # Defaults to "<profile_root>_PROFILE".
+    # You should set this only when you extend your own Profile classes to customise them
+    # and you want to activate the extended profile with an envvar that does not conflict
+    # with the parent profile.
+    profile_activating_envvar = None
+
     props = AttributesList(Property)
 
     # shared loaders
@@ -239,16 +245,23 @@ class Profile:
             return self.active_profile_name
 
     @property
+    def active_profile_name_envvar(self):
+        if self.profile_activating_envvar:
+            return self.profile_activating_envvar
+        else:
+            return f"{self.profile_root}_PROFILE".upper()
+
+    @property
     def active_profile_name(self):
         return (
-            os.environ.get(f"{self.profile_root}_PROFILE".upper(), None) or None
+            os.environ.get(self.active_profile_name_envvar, None) or None
         )
 
     @active_profile_name.setter
     def active_profile_name(self, value):
         if value is None:
             value = ""
-        os.environ[f"{self.profile_root}_PROFILE".upper()] = value
+        os.environ[self.active_profile_name_envvar] = value
 
     @property
     def is_live(self):

--- a/wr_profiles/props.py
+++ b/wr_profiles/props.py
@@ -45,10 +45,10 @@ class Property:
     def __get__(self, instance, owner):
         if instance is None:
             return self
-        return instance.get_prop_value(self)
+        return instance._get_prop_value(self)
 
     def __set__(self, instance, value):
-        instance.set_prop_value(self, value)
+        instance._set_prop_value(self, value)
 
     def __str__(self):
         return "{}({!r})".format(self.__class__.__name__, self.name)
@@ -58,7 +58,7 @@ class Property:
 
     def get_envvar(self, profile):
         assert self.name
-        return "{}{}".format(profile.envvar_prefix, self.name.upper())
+        return "{}{}".format(profile._envvar_prefix, self.name.upper())
 
     @property
     def has_default(self):

--- a/wr_profiles/props.py
+++ b/wr_profiles/props.py
@@ -28,6 +28,14 @@ class Property:
         self._deserializer = deserializer
         self._serializer = serializer
 
+    def replace(self, **kwargs):
+        # name is not cloned unless explicitly passed because this is a Descriptor
+        if self.has_default:
+            kwargs.setdefault('default', self.default)
+        kwargs.setdefault('deserializer', self._deserializer)
+        kwargs.setdefault('serializer', self._serializer)
+        return self.__class__(**kwargs)
+
     def __hash__(self):
         return hash((self.__class__, self.name))
 


### PR DESCRIPTION
New features:
* `Profile.profile_activating_envvar` can be set in your profile class to mark a custom environment variable which is used to determine the active profile.

Breaking interface changes:
* Hide private members of `Profile` class
* Qualify `Profile`-related members with `profile_` prefix to allow user to extend `Profile` class and add their own logic without clashing with `Profile` internals.
* `Profile.get_instance` renamed to `Profile.load`
* `Profile.props` renamed to `Profile.profile_props`
